### PR TITLE
Update capitalized-comments rule

### DIFF
--- a/eslint-config.js
+++ b/eslint-config.js
@@ -47,10 +47,10 @@ module.exports = {
 
     // Make sure comments are starting with an uppercase letter, to encourage correct grammar
     'capitalized-comments': [
-      'error',
+      'warn',
       'always',
       {
-        ignorePattern: 'prettier',
+        ignorePattern: 'prettier|c8',
         ignoreConsecutiveComments: true,
       },
     ],


### PR DESCRIPTION
- Lower the severity from `error` to `warn`. The errors get quite annoying when commenting out code during development and make it hard to see when there are type errors in the files.
- Allow `c8 ignore` comments