### PR TITLE
Revert "Add jsx-runtime plugin"

### DIFF
--- a/eslint-config.js
+++ b/eslint-config.js
@@ -9,7 +9,6 @@ module.exports = {
     'plugin:@typescript-eslint/eslint-recommended',
     'plugin:@typescript-eslint/recommended',
     'plugin:react/recommended',
-    'plugin:react/jsx-runtime',
     'prettier',
   ],
   root: true,


### PR DESCRIPTION
Reverts devoxa/eslint-config#326, because it turns out this is not a great default. Instead, projects that use the `jsx-runtime` (e.g. Next.js applications) should extend their config:

```
"eslintConfig": {
  "extends": ["@devoxa", "plugin:react/jsx-runtime"]
}
```